### PR TITLE
Correct typo in comment on generateHexagon method

### DIFF
--- a/Map.as
+++ b/Map.as
@@ -936,7 +936,7 @@ class PointSelector {
   }
 
   
-  // Generate points on a square grid
+  // Generate points on a hexagon grid
   static public function generateHexagon(size:int, seed:int):Function {
     return function(numPoints:int):Vector.<Point> {
       var points:Vector.<Point> = new Vector.<Point>();


### PR DESCRIPTION
generateHexagon method had comment that referenced creating points on a square grid
